### PR TITLE
Add mgorunuch/postgres-mcp-server to database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Access real-time web information and specialized search capabilities.
 Query and analyze data while maintaining security.
 
 - [@modelcontextprotocol/server-postgres](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) 📱 🏠 - PostgreSQL integration with schema inspection
+- [mgorunuch/postgres-mcp-server](https://github.com/mgorunuch/postgres-mcp-server) 🏃 🏠 - A Go-based MCP server for PostgreSQL databases with security features
 - [@modelcontextprotocol/server-sqlite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite) 🐍 🏠 - SQLite operations with analysis features
 
 ## Extended Capabilities

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,7 @@
 在保持安全的同时查询和分析数据。
 
 - [@modelcontextprotocol/server-postgres](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) 📱 🏠 - PostgreSQL 集成及架构检查
+- [mgorunuch/postgres-mcp-server](https://github.com/mgorunuch/postgres-mcp-server) 🏃 🏠 - 基于 Go 的 PostgreSQL 数据库 MCP 服务器，具有安全功能
 - [@modelcontextprotocol/server-sqlite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite) 🐍 🏠 - 具有分析功能的 SQLite 操作
 
 ## 扩展功能


### PR DESCRIPTION
This PR adds the mgorunuch/postgres-mcp-server to the database section of the README files. 

The postgres-mcp-server is a Go-based MCP server for PostgreSQL databases with built-in security features and easy installation options through Homebrew.